### PR TITLE
Update corrstats.py with print function parentheses

### DIFF
--- a/corrstats.py
+++ b/corrstats.py
@@ -105,8 +105,8 @@ def independent_corr(xy, ab, n, n2 = None, twotailed=True, conf_level=0.95, meth
     else:
         raise Exception('Wrong method!')
 
-print dependent_corr(.40, .50, .10, 103, method='steiger')
-print independent_corr(0.5 , 0.6, 103, 103, method='fisher')
+print(dependent_corr(.40, .50, .10, 103, method='steiger'))
+print(independent_corr(0.5 , 0.6, 103, 103, method='fisher'))
 
 #print dependent_corr(.396, .179, .088, 200, method='zou')
 #print independent_corr(.560, .588, 100, 353, method='zou')


### PR DESCRIPTION
Trying to import this was raising an error in Python 3, so I added parentheses to the dependent and independent_corr tests at the bottom